### PR TITLE
Tested for Mac

### DIFF
--- a/GodoTeX.csproj
+++ b/GodoTeX.csproj
@@ -12,5 +12,9 @@
   <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.1-preview.108"/>
   </ItemGroup>
+   
+   <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.1-preview.108"/>
+  </ItemGroup>
 
 </Project>

--- a/addons/GodoTeX/GodoTeX.csproj
+++ b/addons/GodoTeX/GodoTeX.csproj
@@ -13,9 +13,8 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.1-preview.108"/>
   </ItemGroup>
 
-  <!-- This Include statement for MacOS is a complete blind guess and could not be tested-->
   <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.1-preview.108" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.1-preview.108"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi! Love the project, I'm using it for a complex number graphing calculator. 

I have a Mac, and I found that if I use the Linux No Dependencies version in the MacOS import, everything works properly on my 2021 MacBook Pro. No clue why really. Maybe the library works the same for all Unix systems. 