### PR TITLE
Rename LaTeX to LaTeX2D for consistency

### DIFF
--- a/addons/GodoTeX/GodoTeX.cs
+++ b/addons/GodoTeX/GodoTeX.cs
@@ -14,8 +14,8 @@ public partial class GodoTeX : EditorPlugin {
 		AddCustomType("LaTeX3D", "Sprite3D", spatial_script, texture_red);
 		
 		var texture = GD.Load<Texture2D>("addons/GodoTeX/icon.svg");
-		var script = GD.Load<Script>("addons/GodoTeX/LaTeX.cs");
-		AddCustomType("LaTeX", "Sprite2D", script, texture);
+		var script = GD.Load<Script>("addons/GodoTeX/LaTeX2D.cs");
+		AddCustomType("LaTeX2D", "Sprite2D", script, texture);
 		
 		var texture_button = GD.Load<Texture2D>("addons/GodoTeX/iconButton.svg");
 		var button_script = GD.Load<Script>("addons/GodoTeX/LaTeXButton.cs");
@@ -23,11 +23,10 @@ public partial class GodoTeX : EditorPlugin {
 	}
 
 	public override void _ExitTree() {
-		RemoveCustomType("LaTeX");
+		RemoveCustomType("LaTeX2D");
 		RemoveCustomType("LaTeX3D");
 		RemoveCustomType("LaTeXture");
 		RemoveCustomType("LaTeXButton");
 	}
 }
 #endif
-

--- a/addons/GodoTeX/LaTeX2D.cs
+++ b/addons/GodoTeX/LaTeX2D.cs
@@ -1,7 +1,7 @@
 using Godot;
 
 [Tool]
-public partial class LaTeX : Sprite2D {
+public partial class LaTeX2D : Sprite2D {
 	// The following wordy declarations ensure that changing the properties 
 	// inside the editor causes the expression to re-render.
 	

--- a/sample/Environment.tscn
+++ b/sample/Environment.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://b8ne7pqtnju2y"]
 
-[ext_resource type="Script" path="res://addons/GodoTeX/LaTeX.cs" id="1"]
+[ext_resource type="Script" path="res://addons/GodoTeX/LaTeX2D.cs" id="1"]
 [ext_resource type="Script" path="res://sample/UpdateLatex.gd" id="2"]
 
 [sub_resource type="Image" id="Image_rn8st"]
@@ -18,7 +18,7 @@ image = SubResource("Image_rn8st")
 [node name="Environment" type="Node2D"]
 position = Vector2(319, 195)
 
-[node name="LaTeX" type="Sprite2D" parent="."]
+[node name="LaTeX2D" type="Sprite2D" parent="."]
 position = Vector2(75, -14)
 texture = SubResource("ImageTexture_kluqf")
 offset = Vector2(100, 100)

--- a/sample/UpdateLatex.gd
+++ b/sample/UpdateLatex.gd
@@ -1,6 +1,6 @@
 extends TextEdit
 
-@onready var Latex = get_parent().get_node("LaTeX")
+@onready var Latex = get_parent().get_node("LaTeX2D")
 
 func _on_text_changed():
 	Latex.LatexExpression = self.text


### PR DESCRIPTION
In Godot all the classes that have both 2D and 3D versions include "2D" and "3D" at the end of their names.